### PR TITLE
Display provider information in a side panel on map click

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import { Column, Row } from "simple-flexbox";
 import TopNav from "./components/TopNav";
 import Menu from './components/Menu/Menu';
 import Map from "./components/Map";
+import ProviderDetailList from "./components/ProviderDetailList";
 
 import store from './store';
 
@@ -16,6 +17,7 @@ export default function App() {
         <TopNav />
         <div className="map-container">
           <Menu />
+          <ProviderDetailList />
           <Map />
         </div>
       </div>

--- a/src/actions.js
+++ b/src/actions.js
@@ -4,6 +4,7 @@ export const CHANGE_DISTANCE = 'CHANGE_DISTANCE';
 export const CLEAR_DISTANCE = 'CLEAR_DISTANCE';
 export const SET_SEARCH_COORDINATES = 'SET_SEARCH_COORDINATES';
 export const FILTER_PROVIDERS = 'FILTER_PROVIDERS';
+export const HIGHLIGHT_PROVIDER = 'HIGHLIGHT_PROVIDER';
 
 export function initializeProviders(providers) {
   return {
@@ -16,7 +17,14 @@ export function toggleProviderVisibility(providerType) {
   return {
     type: TOGGLE_TYPE,
     providerType
-  }
+  };
+}
+
+export function displayProviderInformation(provider) {
+  return {
+    type: HIGHLIGHT_PROVIDER,
+    provider
+  };
 }
 
 export function changeDistanceFilter(distance) {
@@ -41,7 +49,7 @@ export function setSearchCenterCoordinates(coordinates) {
 
 export function setFilteredProviders(providers){
   return {
-    type: FILTER_PROVIDERS, 
+    type: FILTER_PROVIDERS,
     providers
   }
 }

--- a/src/components/ProviderDetailList.js
+++ b/src/components/ProviderDetailList.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import { displayProviderInformation } from '../actions';
+
+import './provider-detail-list.css';
+
+function ProviderDetailList({ highlightedProviders, displayProviderInformation }) {
+  const renderProvider = provider => (
+    <div key={provider.name} onClick={e => displayProviderInformation(provider)}>
+      {provider.name}
+    </div>
+  );
+
+  return <div id="provider-detail-list">{highlightedProviders.map(renderProvider)}</div>;
+}
+
+export default connect(
+  ({ highlightedProviders }) => ({ highlightedProviders }),
+  { displayProviderInformation }
+)(ProviderDetailList);

--- a/src/components/provider-detail-list.css
+++ b/src/components/provider-detail-list.css
@@ -1,0 +1,15 @@
+#provider-detail-list {
+  position: absolute;
+  z-index: 1;
+  width: 315px;
+
+  margin: 15px;
+  padding: 4px;
+
+  max-height: 100%;
+
+  right: 0;
+  height: calc(100vh - 4em); /* TODO this should be flex box column */
+  background-color: white;
+  filter: drop-shadow(0 3px 3px gray);
+}

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -1,15 +1,36 @@
 import dotProp from 'dot-prop-immutable';
 
-import { INITIALIZE_PROVIDERS, TOGGLE_TYPE, CLEAR_DISTANCE, CHANGE_DISTANCE, SET_SEARCH_COORDINATES } from './actions';
+import {
+  INITIALIZE_PROVIDERS,
+  TOGGLE_TYPE,
+  CLEAR_DISTANCE,
+  CHANGE_DISTANCE,
+  SET_SEARCH_COORDINATES,
+  HIGHLIGHT_PROVIDER
+} from './actions';
 
 export function providerTypes(state = [], action) {
   switch (action.type) {
     case INITIALIZE_PROVIDERS:
       return groupProvidersByType(action.providers);
     case TOGGLE_TYPE:
-    
-    const typeIndex = state.findIndex(type => type.id === action.providerType);
+      const typeIndex = state.findIndex(type => type.id === action.providerType);
       return dotProp.toggle(state, `${typeIndex}.visible`);
+    default:
+      return state;
+  }
+}
+
+export function highlightedProviders(state = [], action) {
+  switch (action.type) {
+    case HIGHLIGHT_PROVIDER: {
+      const providerIndex = state.findIndex(provider => provider.name === action.provider.name);
+      if (providerIndex > -1) {
+        return dotProp.delete(state, providerIndex);
+      } else {
+        return [...state, action.provider];
+      }
+    }
     default:
       return state;
   }
@@ -42,7 +63,7 @@ export function filters(state = [], action) {
       return state;
     }
   }
-  
+
 // searches [{
 //   location: {
 //     searchTerm
@@ -53,11 +74,11 @@ export function filters(state = [], action) {
 
 // searchTerm searchLocation searchString searchAddress
 // search {
-//   term 
-//   coordinates 
+//   term
+//   coordinates
 
 // }
-// focusPoint referenceCoordinates centerCoordinates searchPoint epicenter searchCenter groundZero bullseye axisMundi nucleus center 
+// focusPoint referenceCoordinates centerCoordinates searchPoint epicenter searchCenter groundZero bullseye axisMundi nucleus center
 
 export function search(state = [], action) {
   switch (action.type) {


### PR DESCRIPTION
*This needs additional input from design before it can be merged.*

This shows provider names in a right-side pane when a provider is clicked on in the map. Clicking on a provider name in the side panel OR clicking on the provider again in the map removes the provider from the side panel.

This addresses [Anibel can see priority information about a given service (with an address)](https://trello.com/c/NZ7O1qvm).