### PR TITLE
Restructure selectors to handle sort order and multiple filters (aka "Flat Menu")

### DIFF
--- a/src/components/Map/map.js
+++ b/src/components/Map/map.js
@@ -242,7 +242,7 @@ class Map extends Component {
           telephone: properties["Telephone:"],
           timestamp: properties.Timestamp,
           // Type of Service
-          category: properties["Type of Service"], // better name to map to?
+          typeName: properties["Type of Service"], // synonym for next line
           "Type of Service": properties["Type of Service"], // as referenced in reducer helper function
           // Validated By
           website: properties.Website

--- a/src/components/Menu/menu.container.js
+++ b/src/components/Menu/menu.container.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
 import {
-  toggleProviderVisibility,
   saveProvider,
   clearDistanceFilter,
   changeDistanceFilter,
@@ -25,7 +24,6 @@ const mapStateToProps = state => {
     savedProviders: state.providers.savedProviders,
     visaTypes: VISA_TYPES,
     highlightedProviders: state.highlightedProviders,
-    visibleTypes: state.providerTypes.visible,
     filters: state.filters,
     providerTypes: state.providerTypes.allIds
   };
@@ -33,9 +31,6 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => {
   return {
-    toggleProviderVisibility: providerType => {
-      dispatch(toggleProviderVisibility(providerType));
-    },
     saveProvider: id => {
       dispatch(saveProvider(id));
     },

--- a/src/components/Menu/menu.js
+++ b/src/components/Menu/menu.js
@@ -8,9 +8,7 @@ class Menu extends Component {
     const {
       providersList,
       savedProviders,
-      visibleTypes,
       saveProvider,
-      toggleProviderVisibility,
       highlightedProviders,
       displayProviderInformation
     } = this.props;
@@ -27,8 +25,6 @@ class Menu extends Component {
                       key={providerType.id}
                       id={providerType.id}
                       text={providerType.name}
-                      expanded={visibleTypes.includes(providerType.id)}
-                      onToggle={toggleProviderVisibility}
                     >
                       {providerType.providers.map(provider => (
                         <li
@@ -40,7 +36,6 @@ class Menu extends Component {
                           <MenuDropdownItem
                             key={provider.id}
                             provider={provider}
-                            providerTypeName={providerType.name}
                             isHighlighted={highlightedProviders.includes(
                               provider.id
                             )}

--- a/src/components/MenuDropdown/menu-dropdown.js
+++ b/src/components/MenuDropdown/menu-dropdown.js
@@ -1,29 +1,19 @@
 import React from "react";
-import classNames from "classnames";
 import { Row } from "simple-flexbox";
 import "./menu-dropdown.css";
 
 export default function MenuDropdown({
-  id,
-  onToggle,
   text,
-  expanded,
   children
 }) {
-  const onMenuClicked = () => {
-    onToggle(id);
-  };
-
   return (
     <>
       <Row
-        onClick={onMenuClicked}
-        className={classNames(["dropdown-menu", { expanded }])}
+        className="dropdown-menu"
       >
         <span style={{ flexGrow: 1 }}>{text}</span>
-        <div>{expanded ? "^" : "v"}</div>
       </Row>
-      {expanded && children}
+      {children}
     </>
   );
 }

--- a/src/components/MenuDropdownItem/menu-dropdown-item.js
+++ b/src/components/MenuDropdownItem/menu-dropdown-item.js
@@ -26,7 +26,6 @@ export default class DropdownMenuItem extends React.Component {
   render() {
     const {
       provider,
-      providerTypeName,
       isSaved,
       toggleSavedStatus,
       isHighlighted
@@ -40,7 +39,7 @@ export default class DropdownMenuItem extends React.Component {
             <div className="wrapped-info">
               <div className={`prov-type ${expand}`}>
                 <FontAwesomeIcon icon={faUsers} />
-                <p>{providerTypeName}</p>
+                <p>{provider.typeName}</p>
               </div>
               {!isHighlighted && (
                 <div className="wrapped-icons">

--- a/src/redux/search.js
+++ b/src/redux/search.js
@@ -3,7 +3,7 @@ import { SET_SEARCH_COORDINATES } from "./actions";
 const INITIAL_STATE = {
   mapCenter: [-71.066954, 42.359947], 
   coordinates: [-71.066954, 42.359947],
-  currentLocation: null, //references item in history object once user submits search string
+  currentLocation: "default", //references item in history object once user submits search string
   history: {
     "default": {
       coordinates: [-71.066954, 42.359947],

--- a/src/redux/selectors.js
+++ b/src/redux/selectors.js
@@ -3,53 +3,69 @@ import { createSelector } from "reselect";
 
 const getProviderTypesIds = state => state.providerTypes.allIds;
 const getProviderTypesById = state => state.providerTypes.byId;
+const getVisibleProviderTypes = state => state.providerTypes.visible;
 const getProvidersById = state => state.providers.byId;
 const getDistance = state => state.filters.distance;
 const getSavedProvidersIds = state => state.providers.savedProviders;
 const getHighlightedProvidersList = state => state.highlightedProviders;
-// const getSearchCoordinates = state => state.search.history[state.search.currentLocation];
-const getSearchCoordinates = state => state.search.currentLocation ? state.search.history[state.search.currentLocation] : null; // TODO: separate coordinates and searched location
+const getSearchCoordinates = state => state.search.history[state.search.currentLocation];
+// const getSearchCoordinates = state => state.search.currentLocation ? state.search.history[state.search.currentLocation] : null; // TODO: separate coordinates and searched location
 
 export const getProvidersSorted = createSelector(
   [
-    getProviderTypesIds,
     getProviderTypesById,
+    getVisibleProviderTypes,
     getProvidersById,
     getDistance,
     getSearchCoordinates
+    // visa status,
+    // accepting new clients,
+    // sort criterion
   ],
   (
-    providerTypesIds,
     providerTypesById,
+    visibleProviderTypes,
     providersById,
     distance,
     searchCoordinates
   ) => {
-    const sortBy = "DISTANCE"; // TODO: remove after implementing alphabetical sort and tracking sort method in state
-    if (sortBy === "DISTANCE" && searchCoordinates) {
+    const sortMethod = "DISTANCE"; // TODO: remove after implementing alphabetical sort and tracking sort method in state
+
+    // for each provider type that is active, get providers belonging to it that are near the search location
+    // TODO: limit based on new client status and visa type
+    let groupedByProviderType = visibleProviderTypes.map(id => {
+      let providerType = providerTypesById[id];
+      let providers = providerType.providers.map(provId => providersById[provId]);
       const options = { units: "miles" };
-      const refLocation = searchCoordinates.coordinates;
-      const providersList = providerTypesIds.map(typeId => ({
-        id: typeId,
-        name: providerTypesById[typeId].name,
-        providers: getProvidersWithDistance(
-          providerTypesById[typeId].providers, // array of id's
-          providersById,
-          refLocation,
-          options
-        )
-      }));
-      return providersList;
-    } else {
-      const providersList = providerTypesIds.map(typeId => ({
-        id: typeId,
-        name: providerTypesById[typeId].name,
-        providers: providerTypesById[typeId].providers.map(
-          id => providersById[id]
-        )
-      }));
-      return providersList;
+      let providersWithDistances = calculateProviderDistances(
+        providers,
+        searchCoordinates,
+        options
+      )
+      let nearbyProviders = distance ? getProvidersWithinDistance( providersWithDistances, distance ) : providersWithDistances;
+      return {
+        ...providerType,
+        providers: nearbyProviders
+      }
+    });
+
+    // sort and return an array of grouped providers
+    // (for distance and alphabetical, it's a single-object array)
+    switch (sortMethod) {
+      case "DISTANCE":
+        let flattenedProviders = groupedByProviderType.reduce( (result, type) => result.concat(type.providers), [] )
+        let sortedByDistance = sortProvidersByDistance(flattenedProviders)
+        return [{
+          id: "distance-sort",
+          name: "Closest to farthest",
+          providers: sortedByDistance
+        }]
+      case "NAME": // TODO
+      case "PROVIDER_TYPE":
+      default:
+        return groupedByProviderType;
     }
+
   }
 );
 
@@ -82,25 +98,30 @@ export const getHighlightedProviders = createSelector(
   }
 );
 
-function getProvidersWithDistance(
-  providersArray,
-  providersById,
+function calculateProviderDistances(
+  providers,
   refLocation,
   options
 ) {
-  var referencePoint = point(refLocation);
-  var providers = providersArray.map( providerId => {
-    let provider = providersById[providerId];
+  var referencePoint = point(refLocation.coordinates);
+  return providers.map( provider => {
     // New object with the distance attached
     return {
       ...provider,
       distance: distance(point(provider.coordinates), referencePoint, options)
     }
   })
-  return sortByDistance(providers)
 }
 
-function sortByDistance(providerArray) {
+
+function getProvidersWithinDistance(
+  providers,
+  maxDistance,
+) {
+  return providers.filter( provider => maxDistance && provider.distance < maxDistance )
+}
+
+function sortProvidersByDistance(providerArray) {
     // Sort the list by distance
     return providerArray.sort(
       (a, b) => a.distance - b.distance


### PR DESCRIPTION
NOTE: It's going to look broken because no providers are shown by default. And since filter components are being reworked for the top bar, user interaction can't change them, so the results list stays empty. But manually dispatching actions shows desired filtering and sorting behavior as far as I can tell

Providers are always sorted by distance — and that is hard coded into selectors at present because sort order isn't in redux yet (in main repo at least). Stubs for sorting by name or provider type are in `selectors.js` though, and the ordering by provider type can be restored by through `sortOrder`

Toggling of \<MenuDropdown\> is disabled, so now the names of the provider types function as section headers in a flat list (when ordering is by type)