### PR TITLE
Add Liam with cfb email, remove thad personal email

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Thanks for choosing to support our initiative to support and strengthen migrant 
 - Mall Wood mal.wood@mapbox.com,
 - Joe Clark joe.clark@mapbox.com,
 
-### Code4Boston Support:
+### Code for Boston Support:
 
-- Thad Kerosky <thadknull@gmail.com>
+- Liam Morley liam@codeforboston.org
 - Matt mattz@codeforboston.org
 
 ## Project Materials and Communications


### PR DESCRIPTION
Hello – my personal email was on the readme so I just switched that up with Liam's CfB email.

Just had a nice meeting at Mapbox HQ in DC and their community team sends greetings to all working on the project.