### PR TITLE
Mattcardarelli see more visa options

### DIFF
--- a/src/components/Dropdowns/checkbox-dropdown.js
+++ b/src/components/Dropdowns/checkbox-dropdown.js
@@ -14,8 +14,10 @@ export default class CheckBoxDropdown extends React.Component {
     const {
       className,
       options,
+      footer,
       header,
       expanded,
+      onToggleExpanded,
       //visibleTypes
       onChange = () => {}
     } = this.props;
@@ -47,7 +49,9 @@ export default class CheckBoxDropdown extends React.Component {
         className={className}
         header={header}
         content={inputDiv}
+        footer={footer}
         expanded={expanded}
+        onToggleExpanded={onToggleExpanded}
       />
     );
   }

--- a/src/components/Dropdowns/expandable.js
+++ b/src/components/Dropdowns/expandable.js
@@ -15,8 +15,8 @@ export default class Expandable extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if (this.state.expanded !== prevState.expanded) {
-      this.props.onToggleExpanded(this.state.expanded);
+    if (this.props.onToggleExpanded && (this.state.expanded !== prevState.expanded)) {
+       this.props.onToggleExpanded(this.state.expanded);
     }
   }
 
@@ -45,7 +45,7 @@ export default class Expandable extends React.Component {
           <div className={`expanded-content ${expanded ? "expanded" : ""}`}>
             {content}
           </div>
-          <div className={`expandable-footer`}>
+          <div className={`expanded-content ${expanded ? "expanded" : ""}`}>
             {footer}
           </div>
         </div>

--- a/src/components/Dropdowns/expandable.js
+++ b/src/components/Dropdowns/expandable.js
@@ -13,6 +13,12 @@ export default class Expandable extends React.Component {
     };
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    if (this.state.expanded !== prevState.expanded) {
+      this.props.onToggleExpanded(this.state.expanded);
+    }
+  }
+
   toggleExpanded = () => {
     const { expanded } = this.state;
     this.setState({ expanded: !expanded });
@@ -20,7 +26,7 @@ export default class Expandable extends React.Component {
 
   render() {
     const { expanded } = this.state;
-    const { className, content, header } = this.props;
+    const { className, content, footer, header, } = this.props;
 
     return (
       <div className={`expandable-container`}>
@@ -34,6 +40,9 @@ export default class Expandable extends React.Component {
           </div>
           <div className={`expanded-content ${expanded ? "expanded" : ""}`}>
             {content}
+          </div>
+          <div className={`expandable-footer`}>
+            {footer}
           </div>
         </div>
       </div>

--- a/src/components/TopBar/top-bar.container.js
+++ b/src/components/TopBar/top-bar.container.js
@@ -17,7 +17,13 @@ const VISA_TYPES = [
   "Temporary Agricultural Worker H-2A",
   "H-1B",
   "Permanent Resident Card (I-551)",
-  "Advance Parole (I-512)"
+  "Advance Parole (I-512)",
+  "Demo Type 1 (D1)",
+  "Demo Type 2 (D2)",
+  "Demo Type 3 (D3)",
+  "Demo Type 4 (D4)",
+  "Demo Type 5 (D5)",
+  "Demo Type 6 (D6)",
 ];
 
 const TopBarContainer = props => {

--- a/src/components/TopBar/visa-status-dropdown.js
+++ b/src/components/TopBar/visa-status-dropdown.js
@@ -3,7 +3,10 @@ import CheckBoxDropdown from "../Dropdowns/checkbox-dropdown";
 
 const defaultSubheaderText = "Current Visa Status";
 export default class VisaStatusDropdown extends React.Component {
-  state = { subheaderText: defaultSubheaderText };
+  state = {
+    subheaderText: defaultSubheaderText,
+    viewAllOptions: false,
+  };
 
   onCheckboxChanged = (option, selectedValues) => {
     const { onChange } = this.props;
@@ -17,13 +20,30 @@ export default class VisaStatusDropdown extends React.Component {
     }
   };
 
+  onSeeMore = () => {
+    this.setState({
+      viewAllOptions: true
+    });
+  }
+
+  onSeeLess = (expanded) => {
+    if (!expanded) {
+      this.setState({
+        viewAllOptions: false
+      });
+    }
+  }
+
   render() {
     const { className, visaTypes } = this.props;
-    const { subheaderText } = this.state;
+    const { subheaderText, viewAllOptions } = this.state;
+
+    const preferredVisaTypes = viewAllOptions ? visaTypes : visaTypes.slice(0,1);
+    const footer = <div onClick={this.onSeeMore}>See More</div>;
     return (
       <CheckBoxDropdown
         className={className}
-        options={visaTypes.map(visaType => ({
+        options={preferredVisaTypes.map(visaType => ({
           id: visaType,
           display: visaType
         }))}
@@ -34,6 +54,8 @@ export default class VisaStatusDropdown extends React.Component {
             <p>{subheaderText}</p>
           </>
         }
+        footer={viewAllOptions ? null : footer}
+        onToggleExpanded={this.onSeeLess}
         expanded={true}
       />
     );


### PR DESCRIPTION
Hide all except the "preferred" Visa status options for a provider (we don't have this information so we just grab the first option in the list). Add a "See More" anchor at the bottom of the expanded Visa type dropdown that, when clicked, shows all visa status types. All types are shown until the dropdown is collapsed, at which point it resets.