### PR TITLE
Convert RadioButtonDropdown into a controlled component

### DIFF
--- a/src/components/Dropdowns/radio-button-dropdown.js
+++ b/src/components/Dropdowns/radio-button-dropdown.js
@@ -7,6 +7,7 @@ export default class RadioButtonDropdown extends React.Component {
       className,
       options,
       header,
+      selected,
       onChange = () => {}
     } = this.props;
     const inputDiv = options.map((option, index) => {
@@ -19,6 +20,7 @@ export default class RadioButtonDropdown extends React.Component {
             name="distance-dropdown-button"
             value={text}
             onChange={() => onChange(value, text)}
+            checked={text === selected}
           />
           <label className="expandable-label" htmlFor={text}>
             {text}

--- a/src/components/TopBar/distance-dropdown.js
+++ b/src/components/TopBar/distance-dropdown.js
@@ -42,6 +42,7 @@ export default class DistanceDropdown extends React.Component {
         className={className}
         onChange={this.onRadioButtonChanged}
         options={options}
+        selected={this.state.distanceText}
         header={
           <>
             <Row alignItems="center">


### PR DESCRIPTION
Clearing the dropdown currently doesn't clear the radio button, because the inputs aren't controlled components. Making the radio buttons into controlled components fixes this problem, by making React in control of whether a radio button is checked or not.