### PR TITLE
Matt cardarelli persist visa types in redux

### DIFF
--- a/src/components/Dropdowns/checkbox-dropdown.js
+++ b/src/components/Dropdowns/checkbox-dropdown.js
@@ -18,7 +18,7 @@ export default class CheckBoxDropdown extends React.Component {
       header,
       expanded,
       onToggleExpanded,
-      //visibleTypes
+      visibleTypes,
       onChange = () => {}
     } = this.props;
     const inputDiv = options.map((option, index) => {
@@ -29,6 +29,7 @@ export default class CheckBoxDropdown extends React.Component {
             id={id}
             type="checkbox"
             value={display}
+            checked={visibleTypes.includes(id)}
             name={id}
             onChange={({ target: { checked } }) => {
               this.optionsMappings[id] = checked;

--- a/src/components/Map/map.container.js
+++ b/src/components/Map/map.container.js
@@ -2,6 +2,7 @@ import React from "react";
 import { connect } from "react-redux";
 import {
   initializeProviders,
+  initializeVisaFilter,
   setSearchCenterCoordinates,
   displayProviderInformation,
   setMapObject
@@ -28,6 +29,9 @@ const mapDispatchToProps = dispatch => {
   return {
     initializeProviders: providers => {
       dispatch(initializeProviders(providers));
+    },
+    initializeVisaFilter: visas => {
+      dispatch(initializeVisaFilter(visas));
     },
     displayProviderInformation: id => {
       dispatch(displayProviderInformation(id));

--- a/src/components/Map/map.js
+++ b/src/components/Map/map.js
@@ -51,6 +51,8 @@ class Map extends Component {
     // setMapObject(map);
     map.addControl(new mapboxgl.NavigationControl());
     map.on("load", () => {
+      initializeVisaFilter(PLACEHOLDER_VISA_TYPES);
+
       this.removeLayersFromOldDataSet();
       const providerFeatures = map.querySourceFeatures("composite", {
         sourceLayer: "Migrant_Services_-_MSM_Final_1"
@@ -58,9 +60,6 @@ class Map extends Component {
       const normalizedProviders = normalizeProviders(providerFeatures);
       initializeProviders(normalizedProviders);
 
-      initializeVisaFilter({
-        allVisas: PLACEHOLDER_VISA_TYPES
-      });
 
       const allSymbolLayers = [...providerTypes.allIds, "highlightedProviders"];
       allSymbolLayers.forEach(typeId => {

--- a/src/components/Map/map.js
+++ b/src/components/Map/map.js
@@ -16,6 +16,19 @@ import {
   removeDistanceMarkers
 } from "./utilities.js";
 
+const PLACEHOLDER_VISA_TYPES = [
+  "Temporary Agricultural Worker H-2A",
+  "H-1B",
+  "Permanent Resident Card (I-551)",
+  "Advance Parole (I-512)",
+  "Demo Type 1 (D1)",
+  "Demo Type 2 (D2)",
+  "Demo Type 3 (D3)",
+  "Demo Type 4 (D4)",
+  "Demo Type 5 (D5)",
+  "Demo Type 6 (D6)"
+];
+
 mapboxgl.accessToken =
   "pk.eyJ1IjoicmVmdWdlZXN3ZWxjb21lIiwiYSI6ImNqZ2ZkbDFiODQzZmgyd3JuNTVrd3JxbnAifQ.UY8Y52GQKwtVBXH2ssbvgw";
 
@@ -28,7 +41,7 @@ class Map extends Component {
 
   componentDidMount() {
     const { mapCenter, coordinates } = this.props.search;
-    const { providerTypes, initializeProviders } = this.props;
+    const { providerTypes, initializeProviders, initializeVisaFilter } = this.props;
     const map = new mapboxgl.Map({
       container: "map", // container id
       style: "mapbox://styles/refugeeswelcome/cjh9k11zz15ds2spbs4ld6y9o", // stylesheet location
@@ -44,6 +57,10 @@ class Map extends Component {
       });
       const normalizedProviders = normalizeProviders(providerFeatures);
       initializeProviders(normalizedProviders);
+
+      initializeVisaFilter({
+        allVisas: PLACEHOLDER_VISA_TYPES
+      });
 
       const allSymbolLayers = [...providerTypes.allIds, "highlightedProviders"];
       allSymbolLayers.forEach(typeId => {

--- a/src/components/TopBar/provider-type-dropdown.js
+++ b/src/components/TopBar/provider-type-dropdown.js
@@ -3,25 +3,22 @@ import CheckBoxDropdown from "../Dropdowns/checkbox-dropdown";
 
 const defaultSubheaderText = "Not Selected";
 export default class ProviderTypeDropdown extends React.Component {
-  state = { subheaderText: defaultSubheaderText };
-
   onCheckboxChanged = (changedOption, selectedValues) => {
     const { onChange, providerTypes } = this.props;
     onChange(changedOption);
-    if (selectedValues.length === 0) {
-      this.setState({ subheaderText: defaultSubheaderText });
-    } else if (selectedValues.length === 1) {
-      const selectedProviderType =
-        providerTypes.byId[selectedValues[0].id].name;
-      this.setState({ subheaderText: selectedProviderType });
-    } else {
-      this.setState({ subheaderText: selectedValues.length + " Selected" });
-    }
   };
 
   render() {
     const { className, providerTypes } = this.props;
-    const { subheaderText } = this.state;
+    let subheaderText = defaultSubheaderText;
+
+    if (providerTypes.visible.length === 1) {
+      const selectedProviderType =
+        providerTypes.byId[providerTypes.visible[0]].name;
+      subheaderText = selectedProviderType;
+    } else {
+      subheaderText = providerTypes.visible.length + " Selected"
+    }
 
     return (
       <CheckBoxDropdown

--- a/src/components/TopBar/provider-type-dropdown.js
+++ b/src/components/TopBar/provider-type-dropdown.js
@@ -3,22 +3,25 @@ import CheckBoxDropdown from "../Dropdowns/checkbox-dropdown";
 
 const defaultSubheaderText = "Not Selected";
 export default class ProviderTypeDropdown extends React.Component {
+  state = { subheaderText: defaultSubheaderText };
+
   onCheckboxChanged = (changedOption, selectedValues) => {
     const { onChange, providerTypes } = this.props;
     onChange(changedOption);
+    if (selectedValues.length === 0) {
+      this.setState({ subheaderText: defaultSubheaderText });
+    } else if (selectedValues.length === 1) {
+      const selectedProviderType =
+        providerTypes.byId[selectedValues[0].id].name;
+      this.setState({ subheaderText: selectedProviderType });
+    } else {
+      this.setState({ subheaderText: selectedValues.length + " Selected" });
+    }
   };
 
   render() {
     const { className, providerTypes } = this.props;
-    let subheaderText = defaultSubheaderText;
-
-    if (providerTypes.visible.length === 1) {
-      const selectedProviderType =
-        providerTypes.byId[providerTypes.visible[0]].name;
-      subheaderText = selectedProviderType;
-    } else {
-      subheaderText = providerTypes.visible.length + " Selected"
-    }
+    const { subheaderText } = this.state;
 
     return (
       <CheckBoxDropdown

--- a/src/components/TopBar/top-bar.container.js
+++ b/src/components/TopBar/top-bar.container.js
@@ -13,19 +13,6 @@ import {
 import { getProvidersSorted } from "redux/selectors";
 import TopBar from "./top-bar";
 
-const VISA_TYPES = [
-  "Temporary Agricultural Worker H-2A",
-  "H-1B",
-  "Permanent Resident Card (I-551)",
-  "Advance Parole (I-512)",
-  "Demo Type 1 (D1)",
-  "Demo Type 2 (D2)",
-  "Demo Type 3 (D3)",
-  "Demo Type 4 (D4)",
-  "Demo Type 5 (D5)",
-  "Demo Type 6 (D6)"
-];
-
 const TopBarContainer = props => {
   return <TopBar {...props} />;
 };
@@ -34,7 +21,7 @@ const mapStateToProps = state => {
   return {
     providersList: getProvidersSorted(state),
     savedProviders: state.providers.savedProviders,
-    visaTypes: VISA_TYPES,
+    visaTypes: state.filters.visa,
     highlightedProviders: state.highlightedProviders,
     visibleTypes: state.providerTypes.visible,
     filters: state.filters,

--- a/src/components/TopBar/visa-status-dropdown.js
+++ b/src/components/TopBar/visa-status-dropdown.js
@@ -50,6 +50,7 @@ export default class VisaStatusDropdown extends React.Component {
           display: visaType
         }))}
         onChange={this.onCheckboxChanged}
+        visibleTypes={visaTypes.visible}
         header={
           <>
             <h2>VISA STATUS</h2>

--- a/src/components/TopBar/visa-status-dropdown.js
+++ b/src/components/TopBar/visa-status-dropdown.js
@@ -4,20 +4,12 @@ import CheckBoxDropdown from "../Dropdowns/checkbox-dropdown";
 const defaultSubheaderText = "Current Visa Status";
 export default class VisaStatusDropdown extends React.Component {
   state = {
-    subheaderText: defaultSubheaderText,
     viewAllOptions: false
   };
 
   onCheckboxChanged = (option, selectedValues) => {
     const { onChange } = this.props;
     onChange(option);
-    if (selectedValues.length === 0) {
-      this.setState({ subheaderText: defaultSubheaderText });
-    } else if (selectedValues.length === 1) {
-      this.setState({ subheaderText: selectedValues[0].display });
-    } else {
-      this.setState({ subheaderText: selectedValues.length + " Selected" });
-    }
   };
 
   onSeeMore = () => {
@@ -36,7 +28,14 @@ export default class VisaStatusDropdown extends React.Component {
 
   render() {
     const { className, visaTypes } = this.props;
-    const { subheaderText, viewAllOptions } = this.state;
+    const { viewAllOptions } = this.state;
+    let subheaderText = defaultSubheaderText;
+
+    if (visaTypes.visible.length === 1) {
+      subheaderText = visaTypes.visible[0];
+    } else {
+      subheaderText = visaTypes.visible.length + " Selected";
+    }
 
     const preferredVisaTypes = viewAllOptions
       ? visaTypes.allVisas

--- a/src/components/TopBar/visa-status-dropdown.js
+++ b/src/components/TopBar/visa-status-dropdown.js
@@ -39,8 +39,8 @@ export default class VisaStatusDropdown extends React.Component {
     const { subheaderText, viewAllOptions } = this.state;
 
     const preferredVisaTypes = viewAllOptions
-      ? visaTypes
-      : visaTypes.slice(0, 1);
+      ? visaTypes.allVisas
+      : visaTypes.allVisas.slice(0, 1);
     const footer = <div onClick={this.onSeeMore}>See More</div>;
     return (
       <CheckBoxDropdown

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -60,17 +60,17 @@ export function clearDistanceFilter() {
   };
 }
 
-export function initializeVisaFilter(visa) {
+export function initializeVisaFilter(visas) {
   return {
     type: INITIALIZE_VISA,
-    visa
+    visas
   };
 }
 
 export function changeVisaFilter(visa) {
   return {
     type: CHANGE_VISA,
-    visa
+    visa: visa
   };
 }
 

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -1,4 +1,5 @@
 export const INITIALIZE_PROVIDERS = "INITIALIZE_PROVIDERS";
+export const INITIALIZE_VISA = "INITIALIZE_VISA";
 export const TOGGLE_TYPE = "TOGGLE_TYPE";
 export const CHANGE_DISTANCE = "CHANGE_DISTANCE";
 export const CLEAR_DISTANCE = "CLEAR_DISTANCE";
@@ -56,6 +57,13 @@ export function changeDistanceFilter(distance) {
 export function clearDistanceFilter() {
   return {
     type: CLEAR_DISTANCE
+  };
+}
+
+export function initializeVisaFilter(visa) {
+  return {
+    type: INITIALIZE_VISA,
+    visa
   };
 }
 

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -70,7 +70,7 @@ export function initializeVisaFilter(visas) {
 export function changeVisaFilter(visa) {
   return {
     type: CHANGE_VISA,
-    visa: visa
+    visa
   };
 }
 

--- a/src/redux/filters.js
+++ b/src/redux/filters.js
@@ -1,6 +1,7 @@
 import {
   CHANGE_DISTANCE,
   CLEAR_DISTANCE,
+  INITIALIZE_VISA,
   CHANGE_VISA,
   CLEAR_VISA
 } from "./actions";
@@ -12,10 +13,12 @@ export default function filters(state = {}, action) {
       return { ...state, distance: null };
     case CHANGE_DISTANCE:
       return { ...state, distance: action.distance };
+    case INITIALIZE_VISA:
+      return { ...state, visa: action.visa };
     case CLEAR_VISA: // both init and 'clear' button
       return { ...state, visa: null };
     case CHANGE_VISA:
-      return { ...state, visa: action.visa };
+      return { ...state, visa: action.visa }; /*** THIS WILL NEED TO CHANGE ***/
     default:
       return state;
   }

--- a/src/redux/filters.js
+++ b/src/redux/filters.js
@@ -6,7 +6,12 @@ import {
   CLEAR_VISA
 } from "./actions";
 
-export default function filters(state = {}, action) {
+const INITIAL_VISA_STATE = {
+  allVisas: [],
+  visible: [],
+};
+
+export default function filters(state = { visa: INITIAL_VISA_STATE }, action) {
   // TO ADD LATER: visa status, accepting clients
   switch (action.type) {
     case CLEAR_DISTANCE: // both init and 'clear' button
@@ -14,12 +19,29 @@ export default function filters(state = {}, action) {
     case CHANGE_DISTANCE:
       return { ...state, distance: action.distance };
     case INITIALIZE_VISA:
-      return { ...state, visa: action.visa };
+      return { ...state, visa: {
+        allVisas: action.visas,
+        visible: state.visa.visible
+      } };
     case CLEAR_VISA: // both init and 'clear' button
-      return { ...state, visa: null };
+      return { ...state, visa: INITIAL_VISA_STATE };
     case CHANGE_VISA:
-      return { ...state, visa: action.visa }; /*** THIS WILL NEED TO CHANGE ***/
+      return changeVisa(state, action.visa);
     default:
       return state;
   }
+}
+
+function changeVisa(state, visa) {
+  if (state.visa.visible.includes(visa)) {
+    const removedVisible = state.visa.visible.filter(typeId => visa !== typeId);
+    return { ...state, visa: {
+      allVisas: state.visa.allVisas,
+      visible: removedVisible
+    } };
+  }
+  return { ...state, visa: {
+    allVisas: state.visa.allVisas,
+    visible: [ ...state.visa.visible, visa]
+  } };
 }


### PR DESCRIPTION
Had to refactor the checkbox dropdown a bit to actually use the visibleTypes prop, also had to add some Redux actions and update the reducer for the visa types.

The actual Visa data is still a placeholder but it should be easy to replace with a fetch when we have real data.