### PR TITLE
Remove white background from menu textboxes

### DIFF
--- a/src/components/Dropdowns/expandable.css
+++ b/src/components/Dropdowns/expandable.css
@@ -40,7 +40,6 @@
   padding-top: 6px;
   height: 0px;
   opacity: 0;
-  background-color: white;
   display: flex;
   flex-direction: column;
   pointer-events: none;

--- a/src/components/ProviderList/sort-dropdown.css
+++ b/src/components/ProviderList/sort-dropdown.css
@@ -46,6 +46,7 @@
 .radio-container {
   color: gray;
   padding: 0.75rem;
+  background-color: white;
 }
 .radio-container:hover {
   background-color: #d2e9ff;


### PR DESCRIPTION
Added `background-color: white` to sorting dropdown elements since the background color there would disappear too