### PR TITLE
Remove visa dropdown

### DIFF
--- a/src/components/TopBar/top-bar.js
+++ b/src/components/TopBar/top-bar.js
@@ -1,6 +1,5 @@
 import React, { Component } from "react";
 import "components/ProviderList/provider-list.css";
-import VisaStatusDropdown from "./visa-status-dropdown";
 import ProviderTypeDropdown from "./provider-type-dropdown";
 import Search from "./search";
 import DistanceDropdown from "./distance-dropdown";
@@ -19,10 +18,10 @@ class TopBar extends Component {
 
   render() {
     const {
-      changeVisaFilter,
+      // changeVisaFilter,
       providerTypes,
       toggleProviderVisibility,
-      visaTypes
+      // visaTypes
     } = this.props;
     const topBarItemClass = "top-bar-item";
 

--- a/src/components/TopBar/top-bar.js
+++ b/src/components/TopBar/top-bar.js
@@ -28,11 +28,6 @@ class TopBar extends Component {
 
     return (
       <div className="top-bar">
-        <VisaStatusDropdown
-          className={topBarItemClass}
-          onChange={changeVisaFilter}
-          visaTypes={visaTypes}
-        />
         <ProviderTypeDropdown
           className={topBarItemClass}
           providerTypes={providerTypes}


### PR DESCRIPTION
The intent is to hide the drop-down without ripping out the plumbing. It should be easy to add the drop-down back to the top bar. Lucky for me, we hadn't hooked up the visas to the filter logic in `redux/selectors` yet, so no other changes were needed.