### PR TITLE
Show only saved providers in the map when the saved provider tab is selected

### DIFF
--- a/src/components/Map/map.js
+++ b/src/components/Map/map.js
@@ -277,14 +277,21 @@ class Map extends Component {
   };
 
   geoJSONFeatures = () => {
-    let {providersList, highlightedProviders} = this.props;
+    let { providersList, highlightedProviders, search, providers } = this.props;
+    const showSavedProviders = search.selectedTabIndex === 1;
+    const savedProviderIds = providers.savedProviders;
+
     let forGeoConvert = [];
     providersList.forEach(typeId => {
       typeId.providers.forEach(provider => {
         provider.color = highlightedProviders.includes(provider.id)
           ? "rgb(255,195,26)"
           : iconColors[provider.typeId];
+
+        if (!showSavedProviders || savedProviderIds.includes(provider.id)) {
+        // Show only saved providers if the saved provider tab is selected, otherwise show everything.
         forGeoConvert.push(provider);
+        }
       });
     });
     return convertProvidersToGeoJSON(forGeoConvert);

--- a/src/components/Map/map.js
+++ b/src/components/Map/map.js
@@ -1,8 +1,8 @@
-import React, {Component} from "react";
+import React, { Component } from "react";
 import mapboxgl from "mapbox-gl";
 import MapboxGeocoder from "@mapbox/mapbox-gl-geocoder";
 import "./map.css";
-import {circle, point, transformTranslate} from "@turf/turf";
+import { circle, point, transformTranslate } from "@turf/turf";
 import typeImages from "assets/images";
 import distances from "assets/distances";
 import iconColors from "assets/icon-colors";
@@ -40,7 +40,11 @@ class Map extends Component {
 
   componentDidMount() {
     const { mapCenter, coordinates } = this.props.search;
-    const { providerTypes, initializeProviders, initializeVisaFilter } = this.props;
+    const {
+      providerTypes,
+      initializeProviders,
+      initializeVisaFilter
+    } = this.props;
     const map = new mapboxgl.Map({
       container: "map", // container id
       style: "mapbox://styles/refugeeswelcome/cjh9k11zz15ds2spbs4ld6y9o", // stylesheet location
@@ -59,10 +63,8 @@ class Map extends Component {
       const normalizedProviders = normalizeProviders(providerFeatures);
       initializeProviders(normalizedProviders);
 
-
       const allSymbolLayers = [...providerTypes.allIds, "highlightedProviders"];
       allSymbolLayers.forEach(typeId => {
-
         this.findLayerInMap(typeId);
         this.findClustersInMap();
       });
@@ -116,9 +118,13 @@ class Map extends Component {
   zoomToDistance = distance => {
     let resolution = window.screen.height;
     let latitude = this.props.search.coordinates[1];
-    let milesPerPixel = distance * 8 / resolution;
-    return Math.log2(24901 * Math.cos(latitude * Math.PI / 180) / milesPerPixel) - 8;
-  }
+    let milesPerPixel = (distance * 8) / resolution;
+    return (
+      Math.log2(
+        (24901 * Math.cos((latitude * Math.PI) / 180)) / milesPerPixel
+      ) - 8
+    );
+  };
 
   removeLayersFromOldDataSet = () => {
     const allLayers = this.map.getStyle().layers;
@@ -141,7 +147,7 @@ class Map extends Component {
         id: typeId,
         source: "displayData",
         type: "symbol",
-        filter: ["all", ["!=", "has", "point_count"],["==", "typeId", typeId]],
+        filter: ["all", ["!=", "has", "point_count"], ["==", "typeId", typeId]],
         layout: {
           "icon-image": typeId + "icon",
           "icon-size": 0.3,
@@ -151,10 +157,10 @@ class Map extends Component {
           visibility: "visible"
         },
         paint: {
-          "icon-color": ['get', 'color'],
+          "icon-color": ["get", "color"],
           "icon-halo-color": "white",
-          "icon-halo-width": .5,
-          "icon-halo-blur": 1,
+          "icon-halo-width": 0.5,
+          "icon-halo-blur": 1
         }
       });
 
@@ -163,7 +169,6 @@ class Map extends Component {
   };
 
   findClustersInMap = () => {
-
     this.map.addLayer({
       id: "clusterCircle",
       source: "displayData",
@@ -172,32 +177,31 @@ class Map extends Component {
       paint: {
         "circle-color": "black",
         "circle-radius": 30,
-        "circle-opacity": .35
+        "circle-opacity": 0.35
       }
-
     });
 
     let clusterName = "cluster";
     this.map.addLayer({
-        id: clusterName,
-        source: "displayData",
-        type: "symbol",
-        filter: ["has", "point_count"],
-        layout: {
-          "icon-size": 0.4,
-          "text-field": "{point_count_abbreviated}",
-          "text-font": ["DIN Offc Pro Medium", "Arial Unicode MS Bold"],
-          "text-size": 36,
-          "icon-allow-overlap": true,
-          "icon-ignore-placement": true,
-          'visibility': 'visible'
-        },
-        paint: {
-          "text-color": "black",
-          "text-halo-color": "#ffffff",
-          "text-halo-width": 2
-        }
-      });
+      id: clusterName,
+      source: "displayData",
+      type: "symbol",
+      filter: ["has", "point_count"],
+      layout: {
+        "icon-size": 0.4,
+        "text-field": "{point_count_abbreviated}",
+        "text-font": ["DIN Offc Pro Medium", "Arial Unicode MS Bold"],
+        "text-size": 36,
+        "icon-allow-overlap": true,
+        "icon-ignore-placement": true,
+        visibility: "visible"
+      },
+      paint: {
+        "text-color": "black",
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 2
+      }
+    });
 
     this.addClusterClickHandlerToMapLayer(clusterName);
   };
@@ -226,26 +230,29 @@ class Map extends Component {
     );
   };
 
-  addClusterClickHandlerToMapLayer = (clusterName) => {
-    this.map.on('click', clusterName, function (e) {
+  addClusterClickHandlerToMapLayer = clusterName => {
+    this.map.on("click", clusterName, function(e) {
       let mapView = this;
-      let features = mapView.queryRenderedFeatures(e.point, {layers: [clusterName]});
-
-          let clusterId = features[0].properties.cluster_id;
-          mapView.getSource("displayData").getClusterExpansionZoom(clusterId, function (err, zoom) {
-              if (err)
-                  return;
-
-              mapView.easeTo({
-                             center: features[0].geometry.coordinates,
-                             zoom: zoom
-                         });
-          });
+      let features = mapView.queryRenderedFeatures(e.point, {
+        layers: [clusterName]
       });
+
+      let clusterId = features[0].properties.cluster_id;
+      mapView
+        .getSource("displayData")
+        .getClusterExpansionZoom(clusterId, function(err, zoom) {
+          if (err) return;
+
+          mapView.easeTo({
+            center: features[0].geometry.coordinates,
+            zoom: zoom
+          });
+        });
+    });
   };
 
   addClickHandlerToMapIdLayer = typeId => {
-    let {displayProviderInformation, highlightedProviders} = this.props;
+    let { displayProviderInformation, highlightedProviders } = this.props;
     this.map.on("click", typeId, e => {
       const providerElement = document.getElementById(
         `provider-${e.features[0].properties.id}`
@@ -260,7 +267,7 @@ class Map extends Component {
         const scrollStep = (toScrollTo - panel.scrollTop) / steps;
         let stepCount = 0;
 
-        const scrollInterval = setInterval(function () {
+        const scrollInterval = setInterval(function() {
           if (stepCount < steps) {
             panel.scrollBy(0, scrollStep);
             stepCount++;
@@ -289,20 +296,21 @@ class Map extends Component {
           : iconColors[provider.typeId];
 
         if (!showSavedProviders || savedProviderIds.includes(provider.id)) {
-        // Show only saved providers if the saved provider tab is selected, otherwise show everything.
-        forGeoConvert.push(provider);
+          // Show only saved providers if the saved provider tab is selected, otherwise show everything.
+          forGeoConvert.push(provider);
         }
       });
     });
     return convertProvidersToGeoJSON(forGeoConvert);
   };
 
-  getBoundingBox = (providerIds) => {
-    let lngs = [], lats = [];
+  getBoundingBox = providerIds => {
+    let lngs = [],
+      lats = [];
     for (let a in providerIds) {
       lngs.push(this.props.providers.byId[providerIds[a]].coordinates[0]);
       lats.push(this.props.providers.byId[providerIds[a]].coordinates[1]);
-      }
+    }
 
     const maxLngs = lngs.reduce((a, b) => Math.max(a, b));
     const minLngs = lngs.reduce((a, b) => Math.min(a, b));
@@ -311,15 +319,15 @@ class Map extends Component {
 
     const boundsBox = [[minLngs, minLats], [maxLngs, maxLats]];
     return boundsBox;
+  };
 
-  }
-
-
-  updatePinAndDistanceIndicator = (prevProps) => {
+  updatePinAndDistanceIndicator = prevProps => {
     const distance = this.props.filters.distance;
     const searchCoordinates = this.props.search.coordinates;
-    if (distance === prevProps.filters.distance
-      && searchCoordinates === prevProps.search.coordinates) {
+    if (
+      distance === prevProps.filters.distance &&
+      searchCoordinates === prevProps.search.coordinates
+    ) {
       // Do not render if the relevant props have not changed. This includes
       // the first render of this component, so the marker is not shown until
       // the user starts interacting with the app.
@@ -327,13 +335,13 @@ class Map extends Component {
     }
     // If no distance filter is set, display all distance indicators.
     const distanceIndicatorRadii = distance ? [distance] : distances;
-    const {color, options} = markerStyle;
+    const { color, options } = markerStyle;
     removeDistanceMarkers(this.markerList);
     this.addDistanceIndicatorLayer();
 
     const centerMarker = createCenterMarker();
 
-    const mapPin = new mapboxgl.Marker({element: centerMarker});
+    const mapPin = new mapboxgl.Marker({ element: centerMarker });
     this.markerList.push(mapPin);
     mapPin.setLngLat(searchCoordinates);
 
@@ -348,10 +356,10 @@ class Map extends Component {
         point(searchCoordinates),
         radius,
         90,
-        {units: "miles"}
+        { units: "miles" }
       );
       const distanceMarker = createDistanceMarker(radius, color[i]);
-      const marker = new mapboxgl.Marker({element: distanceMarker});
+      const marker = new mapboxgl.Marker({ element: distanceMarker });
       this.markerList.push(marker);
       return marker.setLngLat(radiusOffset.geometry.coordinates);
     });
@@ -359,8 +367,8 @@ class Map extends Component {
     labels.map(label => label.addTo(this.map));
     mapPin.addTo(this.map);
     this.map
-    .getSource("distance-indicator-source")
-    .setData({type: "FeatureCollection", features: circles});
+      .getSource("distance-indicator-source")
+      .setData({ type: "FeatureCollection", features: circles });
   };
 
   removeReferenceLocation = map => {
@@ -400,17 +408,17 @@ class Map extends Component {
     }
   };
 
-  zoomToFit = (providerIds) => {
-    if(providerIds.length > 1){
+  zoomToFit = providerIds => {
+    if (providerIds.length > 1) {
       const visibleIcons = this.getBoundingBox(providerIds);
       this.map.fitBounds(visibleIcons, {
-        padding: {top: 200, bottom: 200, left: 200, right: 200},
+        padding: { top: 200, bottom: 200, left: 200, right: 200 },
         duration: 2000,
         maxZoom: 13,
-        linear: false,
+        linear: false
       });
     }
-  }
+  };
 
   componentDidUpdate(prevProps) {
     this.setSingleSourceInMap();
@@ -419,7 +427,10 @@ class Map extends Component {
     this.props.providerTypes.allIds.map(typeId => this.findLayerInMap(typeId));
     this.updatePinAndDistanceIndicator(prevProps);
     this.zoomToFit(this.props.highlightedProviders);
-    if (this.props.filters.distance && this.props.filters.distance !== prevProps.filters.distance) {
+    if (
+      this.props.filters.distance &&
+      this.props.filters.distance !== prevProps.filters.distance
+    ) {
       this.map.flyTo({
         center: this.props.search.coordinates,
         zoom: this.zoomToDistance(this.props.filters.distance)
@@ -432,7 +443,7 @@ class Map extends Component {
   }
 
   render() {
-    return <div id="map" className="map"/>;
+    return <div id="map" className="map" />;
   }
 }
 

--- a/src/components/Map/map.js
+++ b/src/components/Map/map.js
@@ -107,10 +107,13 @@ class Map extends Component {
   zoomToDistance = distance => {
     let resolution = window.screen.height;
     let latitude = this.props.search.coordinates[1];
-    let milesPerPixel = distance * 8 / resolution;
-    return Math.log2(24901 * Math.cos(latitude * Math.PI / 180) / milesPerPixel) - 8;
+    let milesPerPixel = (distance * 8) / resolution;
+    return (
+      Math.log2(
+        (24901 * Math.cos((latitude * Math.PI) / 180)) / milesPerPixel
+      ) - 8
+    );
   };
-
 
   setSourceFeatures = features => {
     this.setSingleSourceInMap(); // checks source exists, adds if not
@@ -283,7 +286,7 @@ class Map extends Component {
     return convertProvidersToGeoJSON(forGeoConvert);
   };
 
-  updatePinAndDistanceIndicator = (prevProps) => {
+  updatePinAndDistanceIndicator = prevProps => {
     const distance = this.props.filters.distance;
     const searchCoordinates = this.props.search.coordinates;
     if (
@@ -370,8 +373,8 @@ class Map extends Component {
     }
   };
 
-  zoomToFit = (providerIds) => {
-    if(providerIds.length > 1){
+  zoomToFit = providerIds => {
+    if (providerIds.length > 1) {
       const visibleIcons = getBoundingBox(this.props.providers, providerIds);
       this.map.fitBounds(visibleIcons, {
         padding: { top: 200, bottom: 200, left: 200, right: 200 },
@@ -386,10 +389,15 @@ class Map extends Component {
     if (this.state.loaded) {
       const features = this.geoJSONFeatures();
       this.setSourceFeatures(features);
-      this.props.providerTypes.allIds.map(typeId => this.findLayerInMap(typeId));
+      this.props.providerTypes.allIds.map(typeId =>
+        this.findLayerInMap(typeId)
+      );
       this.updatePinAndDistanceIndicator(prevProps);
       this.zoomToFit(this.props.highlightedProviders);
-      if (this.props.filters.distance && this.props.filters.distance !== prevProps.filters.distance) {
+      if (
+        this.props.filters.distance &&
+        this.props.filters.distance !== prevProps.filters.distance
+      ) {
         this.map.flyTo({
           center: this.props.search.coordinates,
           zoom: this.zoomToDistance(this.props.filters.distance)

--- a/src/components/Map/map.js
+++ b/src/components/Map/map.js
@@ -298,8 +298,6 @@ class Map extends Component {
       // the user starts interacting with the app.
       return;
     }
-    // If no distance filter is set, display all distance indicators.
-    const distanceIndicatorRadii = distance ? [distance] : distances;
     removeDistanceMarkers(this.markerList);
     this.addDistanceIndicatorLayer();
 


### PR DESCRIPTION
[demo](http://aballslab.com:3001)

When the saved provider tab is selected, filter out any visible providers that aren't saved.

For a saved provider to be visible in the map, its provider type must be selected in the dropdown.