### PR TITLE
fixed another bad thing where the clusters didn't work

### DIFF
--- a/src/components/Map/map.js
+++ b/src/components/Map/map.js
@@ -44,7 +44,6 @@ class Map extends Component {
     });
     const normalizedProviders = normalizeProviders(providerFeatures);
     initializeProviders(normalizedProviders);
-    
     this.loadProviderTypeImage(typeImages);
     this.setState({ loaded: true });
   };


### PR DESCRIPTION
in onMapLoaded, moved findClustersInMap outside of providerTypes iteration 