### PR TITLE
Fix lint warnings and Readme commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If you're new to github check out [Github Guide, Hello World](https://guides.git
 3. Clone your fork: In your terminal type `git clone`, paste the URL you copied and press enter. In your terminal/command prompt cd (change directory) into the new folder. Inside the directory:
 
 ```
-git clone
+git clone \
 https://github.com/YOUR-USERNAME/migrant_service_map.git
 cd migrant_service_map
 ```
@@ -72,7 +72,7 @@ cd migrant_service_map
 4. Add the migrant_service_map repository as a remote to your fork:
 
 ```
-git remote add upstream
+git remote add upstream \
 https://github.com/codeforboston/migrant_service_map.git
 ```
 

--- a/src/components/Map/utilities.js
+++ b/src/components/Map/utilities.js
@@ -1,9 +1,6 @@
 import iconColors from "../../assets/icon-colors";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faMapMarkerAlt,
-  faMapMarker,
-} from "@fortawesome/free-solid-svg-icons";
+import { faMapMarkerAlt, faMapMarker } from "@fortawesome/free-solid-svg-icons";
 import ReactDOM from "react-dom";
 import React from "react";
 
@@ -137,10 +134,11 @@ const normalizeProviders = providerFeatures => {
 
 const getBoundingBox = (providers, providerIds) => {
   let lngs = [],
-    lats = [];
-  for (let a in providerIds) {
-    lngs.push(providers.byId[providerIds[a]].coordinates[0]);
-    lats.push(providers.byId[providerIds[a]].coordinates[1]);
+    lats = [],
+    id;
+  for (id in providerIds) {
+    lngs.push(providers.byId[providerIds[id]].coordinates[0]);
+    lats.push(providers.byId[providerIds[id]].coordinates[1]);
   }
 
   const maxLngs = lngs.reduce((a, b) => Math.max(a, b));

--- a/src/components/TopBar/provider-type-dropdown.js
+++ b/src/components/TopBar/provider-type-dropdown.js
@@ -7,7 +7,7 @@ import { faTimes } from "@fortawesome/free-solid-svg-icons";
 const defaultSubheaderText = "Not Selected";
 export default class ProviderTypeDropdown extends React.Component {
   onCheckboxChanged = (changedOption, selectedValues) => {
-    const { onChange, providerTypes } = this.props;
+    const { onChange } = this.props;
     onChange(changedOption);
   };
 


### PR DESCRIPTION
Fix warnings that would appear in the console on load, and make it so copying and pasting the readme commands works by continuing the line.