### PR TITLE
Collapse Dropdowns on Clear

### DIFF
--- a/src/components/Dropdowns/checkbox-dropdown.js
+++ b/src/components/Dropdowns/checkbox-dropdown.js
@@ -17,7 +17,7 @@ export default class CheckBoxDropdown extends React.Component {
       footer,
       header,
       expanded,
-      onToggleExpanded,
+      setExpanded,
       visibleTypes,
       onChange = () => {}
     } = this.props;
@@ -53,7 +53,7 @@ export default class CheckBoxDropdown extends React.Component {
         content={inputDiv}
         footer={footer}
         expanded={expanded}
-        onToggleExpanded={onToggleExpanded}
+        setExpanded={setExpanded}
       />
     );
   }

--- a/src/components/Dropdowns/expandable.js
+++ b/src/components/Dropdowns/expandable.js
@@ -1,45 +1,42 @@
 import React from "react";
 import "./expandable.css";
 
-export default class Expandable extends React.Component {
-  static defaultProps = {
-    expanded: false
-  };
-
-  closeOnSelect = () => {
-    if (this.props.closeOnSelect) {
-      this.props.setExpanded(false);
-    }
-  };
-
-  render() {
-    const { className, content, footer, header, expanded, setExpanded } = this.props;
-
-    return (
+export default function Expandable({
+  className,
+  content,
+  footer,
+  header,
+  expanded = false,
+  setExpanded,
+  onSelect = () => {}
+}) {
+  return (
+    <div
+      className="expandable-container"
+      onMouseEnter={() => setExpanded(true)}
+      onMouseLeave={() => setExpanded(false)}
+    >
       <div
-        className="expandable-container"
-        onMouseEnter={setExpanded(true)}
-        onMouseLeave={setExpanded(false)}
+        className={`expandable-content-wrapper ${className} ${
+          expanded ? "expanded" : ""
+        }`}
       >
         <div
-          className={`expandable-content-wrapper ${className} ${
-            expanded ? "expanded" : ""
-          }`}
+          onClick={() => setExpanded(!expanded)}
+          className="expandable-header"
         >
-          <div onClick={setExpanded(!expanded)} className="expandable-header">
-            {header}
-          </div>
-          <div
-            onClick={this.closeOnSelect}
-            className={`expanded-content ${expanded ? "expanded" : ""}`}
-          >
-            {content}
-          </div>
-          <div className={`expanded-content ${expanded ? "expanded" : ""}`}>
-            {footer}
-          </div>
+          {header}
+        </div>
+        <div
+          onClick={onSelect}
+          className={`expanded-content ${expanded ? "expanded" : ""}`}
+        >
+          {content}
+        </div>
+        <div className={`expanded-content ${expanded ? "expanded" : ""}`}>
+          {footer}
         </div>
       </div>
-    );
-  }
+    </div>
+  );
 }

--- a/src/components/Dropdowns/expandable.js
+++ b/src/components/Dropdowns/expandable.js
@@ -6,48 +6,27 @@ export default class Expandable extends React.Component {
     expanded: false
   };
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      expanded: props.expanded
-    };
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    if (
-      this.props.onToggleExpanded &&
-      this.state.expanded !== prevState.expanded
-    ) {
-      this.props.onToggleExpanded(this.state.expanded);
-    }
-  }
-
-  toggleExpanded = () => {
-    this.setState(state => ({expanded: !state.expanded}));
-  };
-
   closeOnSelect = () => {
     if (this.props.closeOnSelect) {
-      this.setState({ expanded: false });
+      this.props.setExpanded(false);
     }
   };
 
   render() {
-    const { expanded } = this.state;
-    const { className, content, footer, header } = this.props;
+    const { className, content, footer, header, expanded, setExpanded } = this.props;
 
     return (
       <div
         className="expandable-container"
-        onMouseEnter={() => this.setState({ expanded: true })}
-        onMouseLeave={() => this.setState({ expanded: false })}
+        onMouseEnter={setExpanded(true)}
+        onMouseLeave={setExpanded(false)}
       >
         <div
           className={`expandable-content-wrapper ${className} ${
             expanded ? "expanded" : ""
           }`}
         >
-          <div onClick={this.toggleExpanded} className="expandable-header">
+          <div onClick={setExpanded(!expanded)} className="expandable-header">
             {header}
           </div>
           <div

--- a/src/components/Dropdowns/radio-button-dropdown.js
+++ b/src/components/Dropdowns/radio-button-dropdown.js
@@ -8,6 +8,8 @@ export default class RadioButtonDropdown extends React.Component {
       options,
       header,
       selected,
+      expanded,
+      setExpanded,
       onChange = () => {}
     } = this.props;
     const inputDiv = options.map((option, index) => {
@@ -30,7 +32,13 @@ export default class RadioButtonDropdown extends React.Component {
     });
 
     return (
-      <Expandable className={className} header={header} content={inputDiv} />
+      <Expandable
+        className={className}
+        header={header}
+        content={inputDiv}
+        expanded={expanded}
+        setExpanded={setExpanded}
+      />
     );
   }
 }

--- a/src/components/ProviderList/sort-dropdown.js
+++ b/src/components/ProviderList/sort-dropdown.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 import Expandable from "../Dropdowns/expandable";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -7,65 +7,83 @@ import {
   faSortAlphaUp,
   faSortAlphaDown
 } from "@fortawesome/free-solid-svg-icons";
-
 import "./sort-dropdown.css";
 
-const getSortIcon = (sortDirection, incomingState) => {
-  if (incomingState === 'Distance') {
-    if (sortDirection === 'asc') {
-      return faSortNumericUp;
-    }
-    return faSortNumericDown;
-  } else {
-    if (sortDirection === 'asc') {
-      return faSortAlphaUp;
-    }
-    return faSortAlphaDown;
-  }
-};
+export default class SortDropdown extends React.Component {
+  state = {
+    expanded: false
+  };
 
-const SortDropdown = ({
-  className,
-  handleChange,
-  changeDirection,
-  header,
-  incomingState,
-  options,
-  sortDirection,
-}) => {
-  let inputDiv = options.map((option, index) =>
-    <div
-      className={`radio-container ${option === incomingState ? "selected" : null}`}
-      key={index}
-      onClick={() => handleChange(option)}
-    >
-      <input
-        id={option}
-        type="radio"
-        name={option}
-        value={option}
-        checked={option === incomingState}
-        onChange={() => {}}
-      />
-      <label className="expandable-label" htmlFor={option}>
-        {option.toString()}
-      </label>
-    </div>
+  getSortIcon = (sortDirection, incomingState) => {
+    if (incomingState === "Distance") {
+      if (sortDirection === "asc") {
+        return faSortNumericUp;
+      }
+      return faSortNumericDown;
+    } else {
+      if (sortDirection === "asc") {
+        return faSortAlphaUp;
+      }
+      return faSortAlphaDown;
+    }
+  };
+
+  render() {
+    const { expanded } = this.state;
+    const {
+      className,
+      handleChange,
+      changeDirection,
+      header,
+      incomingState,
+      options,
+      sortDirection
+    } = this.props;
+
+    let inputDiv = options.map((option, index) => (
+      <div
+        className={`radio-container ${
+          option === incomingState ? "selected" : null
+        }`}
+        key={index}
+        onClick={() => handleChange(option)}
+      >
+        <input
+          id={option}
+          type="radio"
+          name={option}
+          value={option}
+          checked={option === incomingState}
+          onChange={() => {}}
+        />
+        <label className="expandable-label" htmlFor={option}>
+          {option.toString()}
+        </label>
+      </div>
+    ));
+    let wrappedHeader = (
+      <h4>
+        {header}: {incomingState}
+      </h4>
     );
-    let wrappedHeader = <h4>{header}: {incomingState}</h4>;
 
     return (
-    <div className="sort-container">
-      <Expandable
-        className={className}
-        header={wrappedHeader}
-        content={inputDiv}
-        closeOnSelect={true}
-      />
-      <FontAwesomeIcon size="3x" icon={getSortIcon(sortDirection, incomingState)}
-        onClick={() => changeDirection()} style={{cursor: 'pointer'}}/>
-    </div>
-    )
-};
-
-export default SortDropdown;
+      <div className="sort-container">
+        <Expandable
+          className={className}
+          header={wrappedHeader}
+          content={inputDiv}
+          onSelect={() => this.setState({ expanded: false })}
+          expanded={expanded}
+          setExpanded={expanded => this.setState({ expanded })}
+        />
+        <FontAwesomeIcon
+          size="3x"
+          icon={this.getSortIcon(sortDirection, incomingState)}
+          onClick={() => changeDirection()}
+          style={{ cursor: "pointer" }}
+        />
+      </div>
+    );
+  }
+}

--- a/src/components/TopBar/distance-dropdown.js
+++ b/src/components/TopBar/distance-dropdown.js
@@ -23,12 +23,18 @@ export default class DistanceDropdown extends React.Component {
     event.stopPropagation();
     const { onChange = () => {} } = this.props;
     onChange(undefined);
-    this.setState({ distanceText: defaultDistanceText });
+    this.setState({ distanceText: defaultDistanceText , expanded: false});
+  };
+
+  setExpanded = expanded => {
+    this.setState({
+      expanded
+    });
   };
 
   render() {
     const { className } = this.props;
-    const { distanceText } = this.state;
+    const { distanceText, expanded } = this.state;
     const options = distances.map(distance => {
       if (distance < 0) {
         // "null" clears the filter
@@ -46,6 +52,8 @@ export default class DistanceDropdown extends React.Component {
         onChange={this.onRadioButtonChanged}
         options={options}
         selected={this.state.distanceText}
+        expanded={expanded}
+        setExpanded={this.setExpanded}
         header={
           <>
             <Row alignItems="center">

--- a/src/components/TopBar/distance-dropdown.js
+++ b/src/components/TopBar/distance-dropdown.js
@@ -26,12 +26,6 @@ export default class DistanceDropdown extends React.Component {
     this.setState({ distanceText: defaultDistanceText , expanded: false});
   };
 
-  setExpanded = expanded => {
-    this.setState({
-      expanded
-    });
-  };
-
   render() {
     const { className } = this.props;
     const { distanceText, expanded } = this.state;
@@ -53,7 +47,7 @@ export default class DistanceDropdown extends React.Component {
         options={options}
         selected={this.state.distanceText}
         expanded={expanded}
-        setExpanded={this.setExpanded}
+        setExpanded={(expanded) => this.setState({expanded})}
         header={
           <>
             <Row alignItems="center">

--- a/src/components/TopBar/provider-type-dropdown.js
+++ b/src/components/TopBar/provider-type-dropdown.js
@@ -6,6 +6,10 @@ import { faTimes } from "@fortawesome/free-solid-svg-icons";
 
 const defaultSubheaderText = "Not Selected";
 export default class ProviderTypeDropdown extends React.Component {
+  state = {
+    expanded: false
+  };
+
   onCheckboxChanged = (changedOption, selectedValues) => {
     const { onChange, providerTypes } = this.props;
     onChange(changedOption);
@@ -15,9 +19,18 @@ export default class ProviderTypeDropdown extends React.Component {
     event.stopPropagation();
     const { onChange = () => {} } = this.props;
     onChange(undefined);
+    this.setExpanded(false);
   };
 
+  setExpanded = expanded => {
+    this.setState({
+      expanded
+    });
+  };
+
+
   render() {
+    const {expanded} = this.state;
     const { className, providerTypes } = this.props;
     let subheaderText = defaultSubheaderText;
 
@@ -36,6 +49,8 @@ export default class ProviderTypeDropdown extends React.Component {
           id,
           display: providerTypes.byId[id].name
         }))}
+        expanded={expanded}
+        setExpanded={this.setExpanded}
         onChange={this.onCheckboxChanged}
         visibleTypes={providerTypes.visible}
         header={

--- a/src/components/TopBar/top-bar.js
+++ b/src/components/TopBar/top-bar.js
@@ -4,6 +4,7 @@ import ProviderTypeDropdown from "./provider-type-dropdown";
 import Search from "./search";
 import DistanceDropdown from "./distance-dropdown";
 import "./top-bar.css";
+// import VisaStatusDropdown from "./visa-status-dropdown";
 
 class TopBar extends Component {
   onSearchInputClick = () => {
@@ -20,13 +21,18 @@ class TopBar extends Component {
     const {
       // changeVisaFilter,
       providerTypes,
-      toggleProviderVisibility,
+      toggleProviderVisibility
       // visaTypes
     } = this.props;
     const topBarItemClass = "top-bar-item";
 
     return (
       <div className="top-bar">
+        {/* <VisaStatusDropdown
+          className={topBarItemClass}
+          onChange={changeVisaFilter}
+          visaTypes={visaTypes}
+        /> */}
         <ProviderTypeDropdown
           className={topBarItemClass}
           providerTypes={providerTypes}

--- a/src/components/TopBar/visa-status-dropdown.js
+++ b/src/components/TopBar/visa-status-dropdown.js
@@ -22,7 +22,7 @@ export default class VisaStatusDropdown extends React.Component {
 
   setExpanded = expanded => {
     this.setState({
-      viewAllOptions: !expanded ? false : viewAllOptions,
+      viewAllOptions: !expanded ? false : this.state.viewAllOptions,
       expanded
     });
   };

--- a/src/components/TopBar/visa-status-dropdown.js
+++ b/src/components/TopBar/visa-status-dropdown.js
@@ -6,6 +6,7 @@ const numberOptionsBeforeViewmore = 3
 export default class VisaStatusDropdown extends React.Component {
   state = {
     viewAllOptions: false,
+    expanded: false
   };
 
   onCheckboxChanged = (option, selectedValues) => {
@@ -19,17 +20,16 @@ export default class VisaStatusDropdown extends React.Component {
     });
   };
 
-  onSeeLess = expanded => {
-    if (!expanded) {
-      this.setState({
-        viewAllOptions: false
-      });
-    }
+  setExpanded = expanded => {
+    this.setState({
+      viewAllOptions: !expanded ? false : viewAllOptions,
+      expanded
+    });
   };
 
   render() {
     let { className, visaTypes } = this.props;
-    const { viewAllOptions } = this.state;
+    const { viewAllOptions, expanded } = this.state;
     let subheaderText = defaultSubheaderText;
 
     if (visaTypes.visible.length === 1) {
@@ -57,8 +57,8 @@ export default class VisaStatusDropdown extends React.Component {
           </>
         }
         footer={footerShown}
-        onToggleExpanded={this.onSeeLess}
-        expanded={true}
+        expanded={expanded}
+        setExpanded={this.setExpanded}
       />
     );
   }


### PR DESCRIPTION
The clear icons are rendered by the top-level dropdown components. Expandable currently handles its expanded state internally. To allow clicks on the top-level icons to expand/collapse the dropdown, the expanded state is lifted up to the top-level components. Most of this PR is doing that refactor.

This also simplifies Expandable a bit since onToggleExpanded and closeOnSelect can be move up to the components that actually need those behaviors.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8595776/63891437-2ba3e100-c9b3-11e9-80e6-d81060ed1260.gif)


