### PR TITLE
Use new icon colors for existing, old icons.

### DIFF
--- a/src/components/MenuDropdownItem/menu-dropdown-item.css
+++ b/src/components/MenuDropdownItem/menu-dropdown-item.css
@@ -79,7 +79,6 @@ h5.expanded {
   display: flex;
   flex-direction: row;
   align-items: center;
-  color: #538200;
 }
 
 .prov-type.wrapped {

--- a/src/provider-type-to-color.json
+++ b/src/provider-type-to-color.json
@@ -1,11 +1,11 @@
 {
-  "Job Placement": "#C2530E",
-  "Community Centers": "#25A04C",
-  "Cash/Food Assistance": "#F79F68",
-  "Education": "#0049B3",
-  "Resettlement": "#3FB3C7",
-  "Health": "#F68080",
-  "Mental Health": "#F68080",
-  "Housing": "#3FB3C7",
-  "Legal": "#C2530E"
+  "Job Placement": "#B55023",
+  "Community Center": "#E2484C",
+  "Cash/Food Assistance": "#B55023",
+  "Education": "#915656",
+  "Resettlement": "#1C6BA5",
+  "Health": "#1845A4",
+  "Mental Health": "#1C6BA5",
+  "Housing": "#906D6E",
+  "Legal": "#1845A4"
 }


### PR DESCRIPTION
As per discussion during review of https://github.com/codeforboston/migrant_service_map/pull/194#issuecomment-532485824

We had discussed making them black but it's just as easy to update the colors so I did that. 
![icon-colors](https://user-images.githubusercontent.com/8595776/65104863-fb8fa280-d9a0-11e9-9c9d-c3141c5cf63f.png)
