### PR TITLE
Fix provider list scrolling in Safari

### DIFF
--- a/src/components/ProviderList/sort-dropdown.css
+++ b/src/components/ProviderList/sort-dropdown.css
@@ -17,6 +17,7 @@
   z-index: 2;
   border-bottom: 1px solid hsla(271, 34%, 86%, 0.5);
   box-shadow: 1px 3px 4px rgba(184, 147, 217, 0.2);
+  flex: none;
 }
 .sort-container .expandable-container {
   flex: 1 1 auto;

--- a/src/components/TabbedMenu/tabbed-menu.css
+++ b/src/components/TabbedMenu/tabbed-menu.css
@@ -44,3 +44,8 @@
   min-height: 0;
   box-shadow: 0 0 6px grey;
 }
+
+.selected-tab-panel {
+  display: flex;
+  flex-direction: column;
+}

--- a/src/components/TabbedMenu/tabbed-menu.js
+++ b/src/components/TabbedMenu/tabbed-menu.js
@@ -11,6 +11,7 @@ const TabbedMenu = ({ selectedTabIndex, selectTab }) => {
       className="side-menu"
       selectedIndex={selectedTabIndex}
       onSelect={index => selectTab(index)}
+      selectedTabPanelClassName="selected-tab-panel"
     >
       <TabList>
         <Tab>


### PR DESCRIPTION
The html for the side bar looks like

```
Root
  top-bar
  main
    side-menu
      tab-list
      tab-panel
        panel-container (service-providers)
          header-container (sort-container)
          content-container (providers-list, scrolling)
```

side-menu height is 100% of main (the full map height) with padding. It uses display: flex to distribute the available space between tab-list and tab-panel. tab-list uses flex: initial to remain at its natural size. tab-panel uses flex: auto and min-height:0 to expand to fill the remaining space. This has always worked on all browsers.

panel-container has height: 100%, and so should have the same height as tab-panel. This is the case in Chrome and Firefox, but in Safari this wasn't working and tab-panel was being measured without constraints. Adding display: flex to the active tab-panel seems to propagate the space available to the panel down to the panel container, resulting in the correct height in Safari.

That is to say, when in doubt, use flex ¯\_(ツ)_/¯

Tested on Safari 12.1.1 and Chrome 76