### PR TITLE
In the map, render whatever providers are shown in the active tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lodash": "^4.17.11",
     "mapbox": "^1.0.0-beta10",
     "mapbox-gl": "^0.51.0",
+    "memoize-one": "^5.1.1",
     "npm": "^6.9.0",
     "react": "^16.8.5",
     "react-beautiful-dnd": "^11.0.5",

--- a/src/components/Map/map.container.js
+++ b/src/components/Map/map.container.js
@@ -18,7 +18,6 @@ const mapStateToProps = state => {
   return {
     visibleProviders: getMapProviders(state),
     loadedProviderTypeIds: state.providerTypes.allIds,
-    providers: state.providers,
     highlightedProviders: state.highlightedProviders,
     filters: state.filters,
     search: state.search

--- a/src/components/Map/map.container.js
+++ b/src/components/Map/map.container.js
@@ -7,7 +7,7 @@ import {
   displayProviderInformation,
   setMapObject
 } from "redux/actions";
-import { getProvidersSorted, getMapProviders } from "redux/selectors";
+import { getMapProviders } from "redux/selectors";
 import Map from "./map";
 
 const MapContainer = props => {
@@ -17,8 +17,7 @@ const MapContainer = props => {
 const mapStateToProps = state => {
   return {
     visibleProviders: getMapProviders(state),
-    providersList: getProvidersSorted(state),
-    providerTypes: state.providerTypes,
+    loadedProviderTypeIds: state.providerTypes.allIds,
     providers: state.providers,
     highlightedProviders: state.highlightedProviders,
     filters: state.filters,

--- a/src/components/Map/map.container.js
+++ b/src/components/Map/map.container.js
@@ -7,7 +7,7 @@ import {
   displayProviderInformation,
   setMapObject
 } from "redux/actions";
-import { getProvidersSorted } from "redux/selectors";
+import { getProvidersSorted, getMapProviders } from "redux/selectors";
 import Map from "./map";
 
 const MapContainer = props => {
@@ -16,6 +16,7 @@ const MapContainer = props => {
 
 const mapStateToProps = state => {
   return {
+    visibleProviders: getMapProviders(state),
     providersList: getProvidersSorted(state),
     providerTypes: state.providerTypes,
     providers: state.providers,

--- a/src/components/Map/map.js
+++ b/src/components/Map/map.js
@@ -11,15 +11,17 @@ import {
   createDistanceMarker,
   normalizeProviders,
   removeDistanceMarkers,
-  getBoundingBox,
+  getBoundingBox
 } from "./utilities.js";
 
 mapboxgl.accessToken =
   "pk.eyJ1IjoicmVmdWdlZXN3ZWxjb21lIiwiYSI6ImNqZ2ZkbDFiODQzZmgyd3JuNTVrd3JxbnAifQ.UY8Y52GQKwtVBXH2ssbvgw";
 
 const boundingBox = [
-  -71.562762,42.154131, // Longitude,Latitude near Milford MA
-  -70.647115,42.599752 // Longitude, Latitute near Gloucester MA
+  -71.562762,
+  42.154131, // Longitude,Latitude near Milford MA
+  -70.647115,
+  42.599752 // Longitude, Latitute near Gloucester MA
 ];
 
 class Map extends Component {
@@ -144,8 +146,8 @@ class Map extends Component {
           visibility: "visible"
         }
       });
-    this.addClickHandlerToMapIdLayer(typeId);
-    this.addHoverHandlerToMapIdLayer(typeId);
+      this.addClickHandlerToMapIdLayer(typeId);
+      this.addHoverHandlerToMapIdLayer(typeId);
     }
   };
 
@@ -162,12 +164,11 @@ class Map extends Component {
           "icon-allow-overlap": true,
           "icon-ignore-placement": true,
           "icon-padding": 10,
-          visibility: "visible",
-        },
-      })
+          visibility: "visible"
+        }
+      });
     }
   };
-
 
   findClustersInMap = () => {
     this.map.addLayer({
@@ -179,8 +180,8 @@ class Map extends Component {
         "icon-image": "clustersicon",
         "icon-size": 0.5,
         "icon-allow-overlap": true,
-        "icon-ignore-placement": true,
-      },
+        "icon-ignore-placement": true
+      }
     });
 
     let clusterName = "cluster";
@@ -194,7 +195,7 @@ class Map extends Component {
         "text-field": "{point_count_abbreviated}",
         "text-font": ["DIN Offc Pro Medium", "Arial Unicode MS Bold"],
         "text-size": 26,
-        "text-offset": [0,-0.3],
+        "text-offset": [0, -0.3],
         "icon-allow-overlap": true,
         "icon-ignore-placement": true,
         visibility: "visible"
@@ -273,16 +274,17 @@ class Map extends Component {
       closeButton: false,
       closeOnClick: false,
       className: "name-popup",
-      offset: 20,
+      offset: 20
     });
 
     this.map.on("mouseenter", typeId, e => {
       let popupCoordinates = e.features[0].geometry.coordinates.slice();
       let name = e.features[0].properties.name;
 
-      popup.setLngLat(popupCoordinates)
-          .setHTML(name)
-          .addTo(this.map);
+      popup
+        .setLngLat(popupCoordinates)
+        .setHTML(name)
+        .addTo(this.map);
     });
 
     this.map.on("mouseleave", typeId, () => {
@@ -291,24 +293,14 @@ class Map extends Component {
   };
 
   geoJSONFeatures = () => {
-    let { providersList, highlightedProviders, search, providers } = this.props;
-    const showSavedProviders = search.selectedTabIndex === 1;
-    const savedProviderIds = providers.savedProviders;
-
-    let forGeoConvert = [];
-    providersList.forEach(typeId => {
-      typeId.providers.forEach(provider => {
-        provider.highlighted = highlightedProviders.includes(provider.id)
-          ? "highlighted"
-          : "not-highlighted";
-
-        if (!showSavedProviders || savedProviderIds.includes(provider.id)) {
-          // Show only saved providers if the saved provider tab is selected, otherwise show everything.
-          forGeoConvert.push(provider);
-        }
-      });
-    });
-    return convertProvidersToGeoJSON(forGeoConvert);
+    let { highlightedProviders, visibleProviders = [] } = this.props;
+    let provider;
+    for (provider of visibleProviders) {
+      provider.highlighted = highlightedProviders.includes(provider.id)
+        ? "highlighted"
+        : "not-highlighted";
+    }
+    return convertProvidersToGeoJSON(visibleProviders);
   };
 
   updatePinAndDistanceIndicator = prevProps => {
@@ -431,20 +423,16 @@ class Map extends Component {
     }
   };
 
-  getEnabledHighlightedProviders = (providersList, highlightedProviders) => {
-    const enabledProviderIds = new Set(
-      providersList.flatMap(listByType =>
-        listByType.providers.map(provider => provider.id)
-      )
-    );
-    return highlightedProviders.filter(id => enabledProviderIds.has(id));
+  getVisibleHighlightedProviders = (visibleProviders, highlightedProviders) => {
+    const visibleProviderIds = new Set(visibleProviders.map(provider => provider.id));
+    return highlightedProviders.filter(id => visibleProviderIds.has(id));
   };
 
   zoomToFit = providerIds => {
     providerIds =
       providerIds ||
-      this.getEnabledHighlightedProviders(
-        this.props.providersList,
+      this.getVisibleHighlightedProviders(
+        this.props.visibleProviders,
         this.props.highlightedProviders
       );
     if (providerIds.length > 0) {
@@ -469,12 +457,12 @@ class Map extends Component {
    * track changes to highlighted props.
    */
   zoomToShowNewProviders = prevProps => {
-    const prevIds = this.getEnabledHighlightedProviders(
-        prevProps.providersList,
+    const prevIds = this.getVisibleHighlightedProviders(
+        prevProps.visibleProviders,
         prevProps.highlightedProviders
       ),
-      currIds = this.getEnabledHighlightedProviders(
-        this.props.providersList,
+      currIds = this.getVisibleHighlightedProviders(
+        this.props.visibleProviders,
         this.props.highlightedProviders
       ),
       newIds = currIds.filter(id => !prevIds.includes(id));

--- a/src/components/Map/map.js
+++ b/src/components/Map/map.js
@@ -486,7 +486,7 @@ class Map extends Component {
     if (this.state.loaded) {
       const features = this.geoJSONFeatures();
       this.setSourceFeatures(features);
-      this.props.providerTypes.allIds.map(typeId =>
+      this.props.loadedProviderTypeIds.map(typeId =>
         this.findLayerInMap(typeId)
       );
       this.setSpecialLayerInMap("highlighted", "highlighted");

--- a/src/components/Map/utilities.js
+++ b/src/components/Map/utilities.js
@@ -1,6 +1,6 @@
 import iconColors from "../../assets/icon-colors";
 import mapboxgl from "mapbox-gl";
-import memoizeOne from 'memoize-one';
+import memoizeOne from "memoize-one";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMapMarkerAlt, faMapMarker } from "@fortawesome/free-solid-svg-icons";
 import ReactDOM from "react-dom";

--- a/src/redux/selectors.js
+++ b/src/redux/selectors.js
@@ -8,10 +8,12 @@ const getDistance = state => state.filters.distance;
 const getSavedProvidersIds = state => state.providers.savedProviders;
 const getHighlightedProvidersList = state => state.highlightedProviders;
 const getSearchCoordinates = state =>
-state.search.history[state.search.currentLocation];
+  state.search.history[state.search.currentLocation];
 // const getSearchCoordinates = state => state.search.currentLocation ? state.search.history[state.search.currentLocation] : null; // TODO: separate coordinates and searched location
 const getSortMethod = state => state.providers.sortMethod;
 const getSortDirection = state => state.providers.sortDirection;
+const getResultCase = state =>
+  state.search.selectedTabIndex === 1 ? "saved" : "search";
 
 export const getProvidersSorted = createSelector(
   [
@@ -23,7 +25,7 @@ export const getProvidersSorted = createSelector(
     // visa status,
     // accepting new clients,
     getSortMethod,
-    getSortDirection,
+    getSortDirection
   ],
   (
     providerTypesById,
@@ -48,8 +50,8 @@ export const getProvidersSorted = createSelector(
         options
       );
       let nearbyProviders = distance
-      ? getProvidersWithinDistance(providersWithDistances, distance)
-      : providersWithDistances;
+        ? getProvidersWithinDistance(providersWithDistances, distance)
+        : providersWithDistances;
       return {
         ...providerType,
         providers: sortProvidersByDistance(nearbyProviders)
@@ -64,26 +66,26 @@ export const getProvidersSorted = createSelector(
     );
     switch (sortMethod) {
       case "Distance":
-      return [
-        {
-          id: "distance-sort",
-          name: getDistanceSortText(sortDirection),
-          providers: sortProvidersByDistance(flatList, sortDirection)
-        }
-      ];
+        return [
+          {
+            id: "distance-sort",
+            name: getDistanceSortText(sortDirection),
+            providers: sortProvidersByDistance(flatList, sortDirection)
+          }
+        ];
       case "Name":
-      return [
-        {
-          id: "alphabetical",
-          name: "By name",
-          providers: sortProvidersByName(flatList, sortDirection)
-        }
-      ];
+        return [
+          {
+            id: "alphabetical",
+            name: "By name",
+            providers: sortProvidersByName(flatList, sortDirection)
+          }
+        ];
       case "Provider Type":
-      return sortProvidersByType(groupedByProviderType, sortDirection)
-            
+        return sortProvidersByType(groupedByProviderType, sortDirection);
+
       default:
-      return groupedByProviderType;
+        return groupedByProviderType;
     }
   }
 );
@@ -117,6 +119,25 @@ export const getHighlightedProviders = createSelector(
   }
 );
 
+export const getSearchResultProviders = createSelector(
+  [getProvidersSorted],
+  searchResults => {
+    let resultProvidersById = {};
+    searchResults.forEach(category =>
+      category.providers.forEach(
+        provider => (resultProvidersById[provider.id] = provider)
+      )
+    );
+    return Object.values(resultProvidersById);
+  }
+);
+
+export const getMapProviders = createSelector(
+  [getResultCase, getSearchResultProviders, getSavedProviders],
+  (resultCase, searchProviders, savedProviders) =>
+    resultCase === "saved" ? savedProviders : searchProviders
+);
+
 function calculateProviderDistances(providers, refLocation, options) {
   var referencePoint = point(refLocation.coordinates);
   return providers.map(provider => {
@@ -129,7 +150,9 @@ function calculateProviderDistances(providers, refLocation, options) {
 }
 
 function getDistanceSortText(sortDirection) {
-  return (sortDirection === 'desc' ? "Closest to farthest" : "Farthest to closest");
+  return sortDirection === "desc"
+    ? "Closest to farthest"
+    : "Farthest to closest";
 }
 
 function getProvidersWithinDistance(providers, maxDistance) {
@@ -141,27 +164,27 @@ function getProvidersWithinDistance(providers, maxDistance) {
 function sortProvidersByDistance(providerArray, direction) {
   // Sort the list by distance
   return providerArray.sort((a, b) => {
-    if (direction === 'asc') {
-      return (a.distance < b.distance) ? 1 : -1;
+    if (direction === "asc") {
+      return a.distance < b.distance ? 1 : -1;
     }
-    return (a.distance > b.distance) ? 1 : -1;
+    return a.distance > b.distance ? 1 : -1;
   });
 }
 
 function sortProvidersByName(providerArray, direction) {
   return providerArray.sort((a, b) => {
-    if (direction === 'asc') {
-      return (a.name < b.name) ? 1 : -1;
+    if (direction === "asc") {
+      return a.name < b.name ? 1 : -1;
     }
-    return (a.name > b.name) ? 1: -1;
+    return a.name > b.name ? 1 : -1;
   });
 }
 
 function sortProvidersByType(prividersByType, direction) {
   return prividersByType.sort((a, b) => {
-    if (direction === 'asc') {
-      return (a.id < b.id) ? 1 : -1;
+    if (direction === "asc") {
+      return a.id < b.id ? 1 : -1;
     }
-    return (a.id > b.id) ? 1: -1;
+    return a.id > b.id ? 1 : -1;
   });
 }


### PR DESCRIPTION
Currently, the map only shows providers that appear in the providers list tab. When the saved tab is open, it filters out unsaved providers from the map, but does not show providers that would not appear in the providers list tab. 

This change makes the set of providers rendered in the map always match the visibleProviders prop, and moves logic to determine that prop from the map component and into selectors. 

When the provider list ("search") tab is active, visibleProviders is everything in that list. When the saved tab is active, visibleProviders is all the saved providers.

[demo](aball-msm.web.app)