### PR TITLE
Polish clustering when zoomed in

### DIFF
--- a/src/components/Map/map.js
+++ b/src/components/Map/map.js
@@ -218,7 +218,7 @@ class Map extends Component {
           features: []
         },
         cluster: true,
-        clusterMaxZoom: 80, // Max zoom to cluster points on
+        clusterMaxZoom: 14, // Max zoom to cluster points on
         clusterRadius: 50 // Radius of each cluster when clustering points (defaults to 50)
       });
     }


### PR DESCRIPTION
- Don't cluster when zoomed to level 15 or higher. At this zoom level, providers in adjacent buildings do not overlap, so this prevents clustering providers in the same building.
- When clicking on a cluster, always increase zoom. getClusterExpansionZoom is supposed to return the zoom at which the cluster breaks, but it seems to max out at 14. So increase the zoom by one if we're already at the expansion zoom, to ensure that small/tight clusters break.
 
This should make it so you can just tap on a cluster and eventually the all the provider icons separate.