### PR TITLE
Remove unneeded mapped state and refactor distance

### DIFF
--- a/src/components/Dropdowns/radio-button-dropdown.js
+++ b/src/components/Dropdowns/radio-button-dropdown.js
@@ -20,9 +20,9 @@ export default class RadioButtonDropdown extends React.Component {
             id={text}
             type="radio"
             name={text}
-            value={text}
-            onChange={() => onChange(value, text)}
-            checked={text === selected}
+            value={value}
+            onChange={() => onChange(value)}
+            checked={value === selected}
           />
           <label className="expandable-label" htmlFor={text}>
             {text}

--- a/src/components/TopBar/distance-dropdown.js
+++ b/src/components/TopBar/distance-dropdown.js
@@ -5,7 +5,6 @@ import { Row, Column } from "simple-flexbox";
 
 const distanceText = (distance) => distance ? `${distance} mile${distance === 1 ? "" : "s"}` : 'None Selected';
 
-const defaultDistanceText = "None Selected";
 export default class DistanceDropdown extends React.Component {
   state = { expanded: false };
 

--- a/src/components/TopBar/distance-dropdown.js
+++ b/src/components/TopBar/distance-dropdown.js
@@ -3,30 +3,22 @@ import RadioButtonDropdown from "../Dropdowns/radio-button-dropdown";
 import distances from "assets/distances";
 import { Row, Column } from "simple-flexbox";
 
+const distanceText = (distance) => distance ? `${distance} mile${distance === 1 ? "" : "s"}` : 'None Selected';
+
 const defaultDistanceText = "None Selected";
 export default class DistanceDropdown extends React.Component {
-  state = { distanceText: defaultDistanceText };
-
-  onRadioButtonChanged = (miles, text) => {
-    const { onChange = () => {} } = this.props;
-    onChange(miles);
-    if (miles) {
-      this.setState({ distanceText: text });
-    } else {
-      this.setState({ distanceText: defaultDistanceText });
-    }
-  };
+  state = { expanded: false };
 
   clearDistance = event => {
     event.stopPropagation();
-    const { onChange = () => {} } = this.props;
-    onChange(undefined);
-    this.setState({ distanceText: defaultDistanceText , expanded: false});
+    const { onClear = () => {} } = this.props;
+    onClear();
+    this.setState({ expanded: false });
   };
 
   render() {
-    const { className } = this.props;
-    const { distanceText, expanded } = this.state;
+    const { className, currentDistance, onChange } = this.props;
+    const { expanded } = this.state;
     const options = distances.map(distance => {
       if (distance < 0) {
         // "null" clears the filter
@@ -34,16 +26,16 @@ export default class DistanceDropdown extends React.Component {
       } else {
         return {
           value: distance,
-          text: `${distance} mile${distance === 1 ? "" : "s"}`
+          text: distanceText(distance),
         };
       }
     });
     return (
       <RadioButtonDropdown
         className={className}
-        onChange={this.onRadioButtonChanged}
+        onChange={onChange}
         options={options}
-        selected={this.state.distanceText}
+        selected={currentDistance}
         expanded={expanded}
         setExpanded={(expanded) => this.setState({expanded})}
         header={
@@ -51,7 +43,7 @@ export default class DistanceDropdown extends React.Component {
             <Row alignItems="center">
               <Column flexGrow={1}>
                 <h2 style={{ flex: 1 }}>Distance</h2>
-                <p>{distanceText}</p>
+                <p>{distanceText(currentDistance)}</p>
               </Column>
               <div
                 className="clear-icon-container"

--- a/src/components/TopBar/top-bar.container.js
+++ b/src/components/TopBar/top-bar.container.js
@@ -9,7 +9,6 @@ import {
   clearVisaFilter,
   displayProviderInformation
 } from "redux/actions";
-import { getProvidersSorted } from "redux/selectors";
 import TopBar from "./top-bar";
 
 const TopBarContainer = props => {

--- a/src/components/TopBar/top-bar.container.js
+++ b/src/components/TopBar/top-bar.container.js
@@ -18,14 +18,8 @@ const TopBarContainer = props => {
 
 const mapStateToProps = state => {
   return {
-    providersList: getProvidersSorted(state),
-    savedProviders: state.providers.savedProviders,
-    visaTypes: state.filters.visa,
-    highlightedProviders: state.highlightedProviders,
-    visibleTypes: state.providerTypes.visible,
-    filters: state.filters,
     providerTypes: state.providerTypes,
-    mapObject: state.mapObject
+    distance: state.filters.distance,
   };
 };
 

--- a/src/components/TopBar/top-bar.js
+++ b/src/components/TopBar/top-bar.js
@@ -8,17 +8,15 @@ import "./top-bar.css";
 
 class TopBar extends Component {
 
-  onDistanceSelected = distance => {
-    const { changeDistanceFilter } = this.props;
-    changeDistanceFilter(distance);
-  };
-
   render() {
     const {
-      // changeVisaFilter,
+      distance,
+      changeDistanceFilter,
+      clearDistanceFilter,
       providerTypes,
-      toggleProviderVisibility
+      toggleProviderVisibility,
       // visaTypes
+      // changeVisaFilter,
     } = this.props;
     const topBarItemClass = "top-bar-item";
 
@@ -39,7 +37,9 @@ class TopBar extends Component {
         />
         <DistanceDropdown
           className={topBarItemClass}
-          onChange={this.onDistanceSelected}
+          currentDistance={distance}
+          onChange={changeDistanceFilter}
+          onClear={clearDistanceFilter}
         />
       </div>
     );


### PR DESCRIPTION
This task does two things:
- Removes several unused mapped props from the top bar container.
- Refactors the distance dropdown to a controlled component that is synced directly to the redux store, rather than tracking it's own state locally.

This will prevent unnecessary re-rendering of the top bar when changing data in the providers selector and other parts of the site.