### PR TITLE
Cypress: Wait for the map to load based on class name

### DIFF
--- a/cypress/integration/msm/search.spec.js
+++ b/cypress/integration/msm/search.spec.js
@@ -3,6 +3,7 @@
 context("Search", () => {
   before(() => {
     cy.visit("http://localhost:3000");
+    cy.get(".map-loaded", { timeout: 10000 });
   });
 
   it("results in concentric circles", () => {
@@ -14,9 +15,6 @@ context("Search", () => {
 
     // Perform the search
     cy.get(".mapboxgl-ctrl-geocoder input").type("One Broadway");
-
-    // This is not necessary but it may help in some circumstances
-    cy.wait(3000);
 
     // Select a search result
     cy.get(".suggestions .active a").click();

--- a/src/components/Map/map.js
+++ b/src/components/Map/map.js
@@ -48,6 +48,8 @@ class Map extends Component {
     this.findClustersInMap();
 
     this.loadProviderTypeImage(typeImages);
+
+    this.mapRef.current.classList.add("map-loaded");
     this.setState({ loaded: true });
   };
 


### PR DESCRIPTION
- Add a map-loaded class to the map element once mapbox is loaded
- use cy.get before all tests to check that that class exists, with a 10 second timeout.

cy.get will return once the class exists and the map is loaded, otherwise it will timeout and fail the test. Since it occurs in the before block, other tests will not be run.