### PR TITLE
Commented out a link to something that doesn't exist right now

### DIFF
--- a/public/help/help-guide.html
+++ b/public/help/help-guide.html
@@ -154,10 +154,10 @@
                 How do I search for service providers of a specific type without specifying a location? 
             </summary>
             <p>From the top bar, click the PROVIDER TYPE menu and click on the corresponding boxes to choose the types of service providers to include in your custom list. The chosen service providers will appear under the SERVICE PROVIDER tab and in the map. Clicking on a box a second time will remove the service provider from the SERVICE PROVIDER tab list and the map.</p>
-            <p>
+            <!--<p>
             To move around the map, please refer to the navigation tips here. PUT LINK IN HERE
-            <!--TODO: Link to Navigation Tips-->
-            </p>
+            TODO: Link to Navigation Tips
+            </p>-->
         </details>
         <details>
         <summary> 


### PR DESCRIPTION
There was a reference to "Navigation Tips" which don't exist in the help documentation as it's structured now, so I commented out the line